### PR TITLE
Move landing factor, slope, and runway length inputs to sidebar

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,14 @@ import streamlit as st
 import pandas as pd
 import numpy as np
 
+# Landing distance factors selectable in the sidebar
+factor_options = {
+    "Standard Factor Dry (1.43)": 1.43,
+    "Standard Factor Wet (1.86)": 1.86,
+    "Approved Factor Dry (1.20)": 1.20,
+    "Approved Factor Wet (1.56)": 1.56,
+}
+
 # ─── Page Setup ─────────────────────────────────────────────────────────────
 st.set_page_config(page_title="RFDS QLD B200 Landing Distance Calculator", layout="wide")
 st.title("🛬 RFDS QLD B200 King Air Landing Distance Calculator GRASS SURFACE - NOT FOR OPERATIONAL USE")
@@ -18,6 +26,25 @@ with st.sidebar:
         0,
         1,
         help="Negative = tailwind, Positive = headwind",
+    )
+    factor_label = st.selectbox(
+        "Select Landing Distance Factor",
+        list(factor_options.keys())
+    )
+    slope_deg = st.number_input(
+        "Runway Slope (%)",
+        min_value=-5.0,
+        max_value=0.0,
+        value=0.0,
+        step=0.1,
+        help="Negative = downslope (increases distance), Positive = upslope (no effect)",
+    )
+    avail_m = st.number_input(
+        "Landing Distance Available (m)",
+        min_value=0.0,
+        value=1150.0,
+        step=5.0,
+        help="Enter the runway length available in metres",
     )
 
 # ─── Step 2: Table 1 – Pressure Altitude × OAT (Bilinear Interpolation) ───
@@ -221,18 +248,6 @@ st.markdown("### Final Landing Distance in Meters")
 st.success(f"{obs50_m:.1f} m")
 
 # ─── Step 6: Apply a Factor ───────────────────────────────────
-factor_options = {
-    "Standard Factor Dry (1.43)": 1.43,
-    "Standard Factor Wet (1.86)": 1.86,
-    "Approved Factor Dry (1.20)": 1.20,
-    "Approved Factor Wet (1.56)": 1.56,
-}
-
-# show dropdown and grab the numeric value
-factor_label = st.selectbox(
-    "Select Landing Distance Factor",
-    list(factor_options.keys())
-)
 factor = factor_options[factor_label]
 
 # apply factor to the raw over-50 ft distance
@@ -247,15 +262,7 @@ col2.success(f"{factored_m:.1f} m")
 
 
 
-# ─── Step X: Runway Slope Input & Adjustment (negative = downslope) ─────────
-slope_deg = st.number_input(
-    "Runway Slope (%)",
-    min_value=-5.0,
-    max_value= 0.0,
-    value= 0.0,
-    step= 0.1,
-    help="Negative = downslope (increases distance), Positive = upslope (no effect)"
-)
+# ─── Step X: Runway Slope Adjustment (negative = downslope) ─────────
 
 # For negative slope values, apply 20% extra distance per 1% downslope
 slope_factor = 1.0 + max(-slope_deg, 0.0) * 0.20
@@ -274,14 +281,6 @@ col3.success(f"Distance w/ Slope: **{sloped_ft:.0f} ft**")
 col4.success(f"Distance w/ Slope: **{sloped_m:.1f} m**")
 
 # ─── Step Y: Landing Distance Available & Go/No-Go ─────────────────────────
-# Input available runway length in metres
-avail_m = st.number_input(
-    "Landing Distance Available (m)",
-    min_value=0.0,
-    value=1150.0,
-    step=5.0,
-    help="Enter the runway length available in metres"
-)
 
 # Convert to feet
 avail_ft = avail_m / 0.3048


### PR DESCRIPTION
## Summary
- Add landing factor selection, runway slope, and landing distance available inputs to the sidebar
- Remove duplicate input widgets from main panel

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa8c7dbbf08328b482949a7fd3d287